### PR TITLE
fix typo for 'deprecate' in slide

### DIFF
--- a/presentation/index.html
+++ b/presentation/index.html
@@ -573,7 +573,7 @@
                             - JVM Compiler Control [JEP 165](http://openjdk.java.net/jeps/165)<!-- .element: class="jep" -->
                             - UDP Security (DTLS) [JEP 219](http://openjdk.java.net/jeps/219)<!-- .element: class="jep" -->
                             - Variable Handles [JEP 193](http://openjdk.java.net/jeps/193)<!-- .element: class="jep" -->
-                            - Remove depcreated GC combinations
+                            - Remove deprecated GC combinations
                             [JEP 214](http://openjdk.java.net/jeps/214) <!-- .element: class="jep" -->
                             - Process Import Statements Correctly
                             [JEP 216](http://openjdk.java.net/jeps/216) <!-- .element: class="jep" -->


### PR DESCRIPTION
Just a small typo I noticed while reading your slides.
